### PR TITLE
fix(core): brancher bar no longer disappears on mobile devices

### DIFF
--- a/src/brancher.js
+++ b/src/brancher.js
@@ -2,11 +2,23 @@
 * CSS
 */
 const css_content =`
+html {
+    height: 100vh !important;
+    height: stretch !important;
+    /* TODO remove as soon as 'stretch' is largely available.
+    See: https://caniuse.com/mdn-css_properties_height_stretch*/
+    height: -webkit-fill-available !important;
+}
+
 body {
     margin: 0 !important; /* override user-agent default */
     display: flex !important;
     flex-direction: column !important;
     height: 100vh !important;
+    height: stretch !important;
+    /* TODO remove as soon as 'stretch' is largely available.
+    See: https://caniuse.com/mdn-css_properties_height_stretch*/
+    height: -webkit-fill-available !important;
 }
 
 #brancher-navbar-placeholder {


### PR DESCRIPTION
Fixes a bug related to the fact that the address bar of mobile devices browsers is not fixed but can
appear and disappear, hiding the contents underneath. Now the 'html' and body' tags are set to fill
the available space taking into account the address bar.

Fix: #2